### PR TITLE
Migrating to `pull_request_target` for security

### DIFF
--- a/.github/workflows/ci-a.yml
+++ b/.github/workflows/ci-a.yml
@@ -1,6 +1,6 @@
 name: CI / Microservice A
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:

--- a/.github/workflows/ci-b.yml
+++ b/.github/workflows/ci-b.yml
@@ -1,6 +1,6 @@
 name: CI / Microservice B
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -1,6 +1,6 @@
 name: CI / Microservice C
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:

--- a/.github/workflows/ci-d.yml
+++ b/.github/workflows/ci-d.yml
@@ -1,6 +1,6 @@
 name: CI / Microservice D
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI / Default
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths-ignore:


### PR DESCRIPTION
Given this is a public repository, the move to `pull_request_target` is to reduce the blast radius from any PRs opened along with several other measures:

- ensured that GitHub Actions require approvals for all outside collaborators
- default GitHub Actions automatic token to read permissions
- disabled GitHub Actions ability to create and approve PRs